### PR TITLE
Implement initial padding code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "alpaca"
 version = "0.1.0"
-authors = ["Giovanni Cherubin <g.chers@gmail.com>"]
+authors = [
+  "Giovanni Cherubin <g.chers@gmail.com>",
+  "Noah Vesely <fowlslegs@riseup.net>",
+]
 
 [lib]
 name = "alpaca"
@@ -9,4 +12,3 @@ crate-type = ["dylib"]
 
 [dependencies]
 rand = "0.3"
-pcg_rand = "0.7.0"

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -1,52 +1,337 @@
-use rand::Rng;
-use pcg_rand::Pcg32;
-
 use types::*;
 
-/// Pads an object up to a given size.
-///
-/// Padding varies with respect to the object's type (we assume the provided
-/// extension indicates its correct type).
-/// In HTML and CSS objects, padding is added within a comment.
-/// In other (binary) objects we limit ourselves to appending random bytes.
-///
-/// # Arguments
-///
-/// * `raw` - Object to pad.
-/// * `extension` - The object's extension (e.g., "png").
-/// * `target_size` - The target size.
+use rand::{Rng, sample, weak_rng, XorShiftRng};
+use std::iter::Extend;
+
+static CSS_COMMENT_START: &'static str = "/*";
+const CSS_COMMENT_START_SIZE: usize = 2;
+static CSS_COMMENT_END: &'static str = "*/";
+const CSS_COMMENT_END_SIZE: usize = 2;
+static HTML_COMMENT_START: &'static str = "<!--";
+const HTML_COMMENT_START_SIZE: usize = 4;
+static HTML_COMMENT_END: &'static str = "-->";
+const HTML_COMMENT_END_SIZE: usize = 3;
+
+// Pads an object up to a given size.
+//
+// Padding varies with respect to the object's type (we assume the provided
+// extension indicates its correct type).
+// In HTML and CSS objects, padding is added within a comment.
+// In other (binary) objects we limit ourselves to appending random bytes.
+//
+// # Arguments
+//
+// * `raw` - Object to pad.
+// * `content_type' - The objects content-type header.
+// * `target_size` - The target size.
 #[no_mangle]
-pub extern fn pad_object(raw: &[u8], object_type: &str, target_size: usize) -> *const u8 {
-
-    let mut object = raw.to_vec();
-
-    match object_type {
-        HTML_T => pad_html(&mut object, target_size),
-        CSS_T => pad_css(&mut object, target_size),
-        _ => pad_binary(&mut object, target_size),
-    };
-    
+pub extern fn pad_object(raw: &[u8], content_type: &str, target_size: usize) -> *const u8 {
+    let mut object = Object::from(raw, content_type);
+    let mut rng = weak_rng();
+    object.pad(target_size, &mut rng);
     object.as_ptr()
 }
 
-fn pad_html(raw: &mut Vec<u8>, target_size: usize) {
-    // XXX: better to return new vec in this case?
-    unimplemented!();
+impl Object {
+    fn pad(&mut self, target_size: usize, rng: &mut XorShiftRng) {
+        // Rust's type system guarantees pad_len will be >=0 because
+        // target_size is unsigned. However, Rust panic!s in this case and in
+        // the future we should do proper recovery/ error handling.
+        let pad_len = target_size - self.content.len();
+        let padding = match self.kind {
+            ObjectKind::HTML => get_html_padding(pad_len, rng),
+            ObjectKind::CSS  => get_css_padding(pad_len, rng),
+            _                => get_binary_padding(pad_len, rng),
+        };
+        self.content.extend(padding);
+    }
 }
 
-fn pad_css(raw: &mut Vec<u8>, target_size: usize) {
-    //Pcg32::new_unseeded()
-    //      .gen_ascii_chars();
-    unimplemented!();
+fn get_html_padding(pad_len: usize, rng: &mut XorShiftRng) -> Vec<u8> {
+    // During HTML morphing we should ensure the target size is at least 7
+    // bytes larger than the real HTML to account for the comment opening
+    // and closing syntax.
+    let pad_len = pad_len - HTML_COMMENT_START_SIZE - HTML_COMMENT_END_SIZE;
+    let mut pad = Vec::from(HTML_COMMENT_START);
+    // [34,127) contains only human-readable ascii characters, no
+    // whitespace, and omits '!' to ensure the CSS comment cannot be ended
+    // early by the random generation of the bytes corresponding to '<!--'.
+    pad.extend(sample(rng, 34..127, pad_len));
+    pad.extend(Vec::from(HTML_COMMENT_END));
+    pad
 }
 
-fn pad_binary(raw: &mut Vec<u8>, target_size: usize) {
+fn get_css_padding(pad_len: usize, rng: &mut XorShiftRng) -> Vec<u8> {
+    // During the CSS morphing we should ensure the target size is at least
+    // 4 bytes larger than the real CSS.
+    let pad_len = pad_len - CSS_COMMENT_START_SIZE - CSS_COMMENT_END_SIZE;
+    let mut pad = Vec::from(CSS_COMMENT_START);
+    // [43,127) contains only human-readable ascii characters, no
+    // whitespace, and omits '*' to ensure the CSS comment cannot be ended
+    // early by the random generation of the bytes corresponding to '*/'.
+    pad.extend(sample(rng, 43..127, pad_len));
+    pad.extend(Vec::from(CSS_COMMENT_END));
+    pad
+}
 
-    let pad_len = target_size - raw.len();
+fn get_binary_padding(pad_len: usize, rng: &mut XorShiftRng) -> Vec<u8> {
+    rng.gen_iter::<u8>().take(pad_len).collect::<Vec<u8>>()
+}
 
-    assert!(pad_len >= 0);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    raw.extend(Pcg32::new_unseeded()
-                     .gen_iter::<u8>()
-                     .take(pad_len));
+    use rand::weak_rng;
+    use rand::distributions::{IndependentSample, Range};
+
+    use std::str;
+
+    #[test]
+    fn test_pad_object_html() {
+        let mut rng = weak_rng();
+        let raw_len = Range::new(0, 50).ind_sample(&mut rng);
+        let raw = sample(&mut rng, 34..127, raw_len);
+        assert_eq!(raw.len(), raw_len);
+        let comment_syntax_size = HTML_COMMENT_START_SIZE
+            + HTML_COMMENT_END_SIZE;
+        let pad_len = Range::new(comment_syntax_size, 50)
+            .ind_sample(&mut rng);
+        let target_size = raw_len + pad_len;
+        let ptr = pad_object(&raw, "html", target_size);
+        unsafe {
+            for i in 0..raw_len {
+                assert_eq!(raw[i], *ptr.offset(i as isize));
+            }
+            for i in 0..HTML_COMMENT_START_SIZE {
+                assert_eq!(HTML_COMMENT_START.as_bytes()[i],
+                           *ptr.offset(raw_len as isize + i as isize));
+            }
+            for i in 0..HTML_COMMENT_END_SIZE {
+                assert_eq!(HTML_COMMENT_END.as_bytes()[i],
+                           *ptr.offset(target_size as isize
+                                       - HTML_COMMENT_END_SIZE as isize
+                                       + i as isize));
+            }
+        }
+    }
+
+    #[test]
+    fn test_pad_method_html() {
+        let mut rng = weak_rng();
+        let raw_len = Range::new(0, 50).ind_sample(&mut rng);
+        let raw = sample(&mut rng, 34..127, raw_len);
+        let mut object = Object::from(&raw, "html");
+        assert_eq!(object.content.len(), raw_len);
+        assert!(match object.kind {
+            ObjectKind::HTML => true,
+            _                => false,
+        });
+
+        let comment_syntax_size = HTML_COMMENT_START_SIZE
+            + HTML_COMMENT_END_SIZE;
+        let pad_len = Range::new(comment_syntax_size, 50)
+            .ind_sample(&mut rng);
+        let target_size = raw_len + pad_len;
+        object.pad(target_size, &mut rng);
+        assert_eq!(object.content.len(), target_size);
+        _test_html_padding(object.content[raw_len..].to_vec());
+        // The original object has not changed.
+        assert_eq!(object.content[..raw_len], raw[..])
+    }
+
+    fn _test_html_padding(padding: Vec<u8>) {
+        let mut rng = weak_rng();
+        let comment_syntax_size = HTML_COMMENT_START_SIZE
+            + HTML_COMMENT_END_SIZE;
+        let padding = if padding.len() == 0 {
+            let pad_len = Range::new(comment_syntax_size, 50)
+                .ind_sample(&mut rng);
+            let padding = get_html_padding(pad_len, &mut rng);
+            assert_eq!(padding.len(), pad_len);
+            padding
+        } else {
+            padding
+        };
+        // The padding starts with '<!--'.
+        assert_eq!(&padding[..HTML_COMMENT_START_SIZE],
+                   HTML_COMMENT_START.as_bytes());
+        // The padding ends with '-->'.
+        assert_eq!(&padding[padding.len() - HTML_COMMENT_END_SIZE..],
+                   HTML_COMMENT_END.as_bytes());
+        // Ensure '-->' is not present in the padding.
+        let rand_padding = str::from_utf8(
+            &padding[HTML_COMMENT_START_SIZE
+                     ..padding.len() - HTML_COMMENT_END_SIZE])
+            .unwrap();
+        assert!(!rand_padding.contains(HTML_COMMENT_END));
+    }
+
+    #[test]
+    fn test_get_html_padding() {
+        let padding: Vec<u8> = Vec::new();
+        _test_html_padding(padding);
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_get_html_padding_too_little() {
+        let mut rng = weak_rng();
+        let comment_syntax_size = HTML_COMMENT_START_SIZE
+            + HTML_COMMENT_END_SIZE;
+        let pad_len = Range::new(0, comment_syntax_size)
+            .ind_sample(&mut rng);
+        let padding = get_html_padding(pad_len, &mut rng);
+    }
+
+    #[test]
+    fn test_pad_object_css() {
+        let mut rng = weak_rng();
+        let raw_len = Range::new(0, 50).ind_sample(&mut rng);
+        let raw = sample(&mut rng, 43..127, raw_len);
+        assert_eq!(raw.len(), raw_len);
+        let comment_syntax_size = CSS_COMMENT_START_SIZE
+            + CSS_COMMENT_END_SIZE;
+        let pad_len = Range::new(comment_syntax_size, 50)
+            .ind_sample(&mut rng);
+        let target_size = raw_len + pad_len;
+        let ptr = pad_object(&raw, "css", target_size);
+        unsafe {
+            for i in 0..raw_len {
+                assert_eq!(raw[i], *ptr.offset(i as isize));
+            }
+            for i in 0..CSS_COMMENT_START_SIZE {
+                assert_eq!(CSS_COMMENT_START.as_bytes()[i],
+                           *ptr.offset(raw_len as isize + i as isize));
+            }
+            for i in 0..CSS_COMMENT_END_SIZE {
+                assert_eq!(CSS_COMMENT_END.as_bytes()[i],
+                           *ptr.offset(target_size as isize
+                                       - CSS_COMMENT_END_SIZE as isize
+                                       + i as isize));
+            }
+        }
+    }
+
+    #[test]
+    fn test_pad_method_css() {
+        let mut rng = weak_rng();
+        let raw_len = Range::new(0, 50).ind_sample(&mut rng);
+        let raw = sample(&mut rng, 43..127, raw_len);
+        let mut object = Object::from(&raw, "css");
+        assert_eq!(object.content.len(), raw_len);
+        assert!(match object.kind {
+            ObjectKind::CSS => true,
+            _               => false,
+        });
+
+        let comment_syntax_size = CSS_COMMENT_START_SIZE
+            + CSS_COMMENT_END_SIZE;
+        let pad_len = Range::new(comment_syntax_size, 50)
+            .ind_sample(&mut rng);
+        let target_size = raw_len + pad_len;
+        object.pad(target_size, &mut rng);
+        assert_eq!(object.content.len(), target_size);
+        _test_css_padding(object.content[raw_len..].to_vec());
+        // The original object has not changed.
+        assert_eq!(object.content[..raw_len], raw[..])
+    }
+
+    fn _test_css_padding(padding: Vec<u8>) {
+        let mut rng = weak_rng();
+        let comment_syntax_size = CSS_COMMENT_START_SIZE
+            + CSS_COMMENT_END_SIZE;
+        let padding = if padding.len() == 0 {
+            let pad_len = Range::new(comment_syntax_size, 50)
+                .ind_sample(&mut rng);
+            let padding = get_css_padding(pad_len, &mut rng);
+            assert_eq!(padding.len(), pad_len);
+            padding
+        } else {
+            padding
+        };
+        // The padding starts with '/*'.
+        assert_eq!(&padding[..CSS_COMMENT_START_SIZE],
+                   CSS_COMMENT_START.as_bytes());
+        // The padding ends with '*/'.
+        assert_eq!(&padding[padding.len() - CSS_COMMENT_END_SIZE..],
+                   CSS_COMMENT_END.as_bytes());
+        // Ensure '*/' is not present in the padding.
+        let rand_padding = str::from_utf8(
+            &padding[CSS_COMMENT_START_SIZE
+                     ..padding.len() - CSS_COMMENT_END_SIZE])
+            .unwrap();
+        assert!(!rand_padding.contains(CSS_COMMENT_END));
+    }
+
+    #[test]
+    fn test_get_css_padding() {
+        let padding: Vec<u8> = Vec::new();
+        _test_css_padding(padding);
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_get_css_padding_too_little() {
+        let mut rng = weak_rng();
+        let comment_syntax_size = CSS_COMMENT_START_SIZE
+            + CSS_COMMENT_END_SIZE;
+        let pad_len = Range::new(0, comment_syntax_size)
+            .ind_sample(&mut rng);
+        let padding = get_css_padding(pad_len, &mut rng);
+    }
+
+    #[test]
+    fn test_pad_object_alpaca() {
+        let mut rng = weak_rng();
+        let raw_len = Range::new(0, 50).ind_sample(&mut rng);
+        let raw = rng.gen_iter::<u8>().take(raw_len).collect::<Vec<u8>>();
+        assert_eq!(raw.len(), raw_len);
+        let pad_len = Range::new(0, 50).ind_sample(&mut rng);
+        let target_size = raw_len + pad_len;
+        let ptr = pad_object(&raw, "alpaca", target_size);
+        unsafe {
+            for i in 0..raw_len {
+                assert_eq!(raw[i], *ptr.offset(i as isize));
+            }
+        }
+    }
+
+    #[test]
+    fn test_pad_method_png() {
+        let mut rng = weak_rng();
+        let raw_len = Range::new(0, 50).ind_sample(&mut rng);
+        let raw = rng.gen_iter::<u8>().take(raw_len).collect::<Vec<u8>>();
+        let mut object = Object::from(&raw, "png");
+        assert_eq!(object.content.len(), raw_len);
+        assert!(match object.kind {
+            ObjectKind::IMG => true,
+            _               => false,
+        });
+
+        let pad_len = Range::new(0, 50).ind_sample(&mut rng);
+        let target_size = raw_len + pad_len;
+        object.pad(target_size, &mut rng);
+        assert_eq!(object.content.len(), target_size);
+        // The original object has not changed.
+        assert_eq!(object.content[..raw_len], raw[..])
+    }
+
+    #[test]
+    fn test_get_binary_padding() {
+        let mut rng = weak_rng();
+        let pad_len = Range::new(0, 50).ind_sample(&mut rng);
+        let padding = get_binary_padding(pad_len, &mut rng);
+        assert_eq!(padding.len(), pad_len);
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_pad_object_too_small() {
+        let mut rng = weak_rng();
+        let raw_len = Range::new(1, 50).ind_sample(&mut rng);
+        let raw = rng.gen_iter::<u8>().take(raw_len).collect::<Vec<u8>>();
+        assert_eq!(raw.len(), raw_len);
+        let ptr = pad_object(&raw, "alpaca", raw_len - 1);
+    }
 }

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -97,18 +97,18 @@ mod tests {
         let pad_len = Range::new(comment_syntax_size, 50)
             .ind_sample(&mut rng);
         let target_size = raw_len + pad_len;
-        let ptr = pad_object(&raw, "html", target_size);
+        let obj_ptr = pad_object(&raw, "html", target_size);
         unsafe {
             for i in 0..raw_len {
-                assert_eq!(raw[i], *ptr.offset(i as isize));
+                assert_eq!(raw[i], *obj_ptr.offset(i as isize));
             }
             for i in 0..HTML_COMMENT_START_SIZE {
                 assert_eq!(HTML_COMMENT_START.as_bytes()[i],
-                           *ptr.offset(raw_len as isize + i as isize));
+                           *obj_ptr.offset(raw_len as isize + i as isize));
             }
             for i in 0..HTML_COMMENT_END_SIZE {
                 assert_eq!(HTML_COMMENT_END.as_bytes()[i],
-                           *ptr.offset(target_size as isize
+                           *obj_ptr.offset(target_size as isize
                                        - HTML_COMMENT_END_SIZE as isize
                                        + i as isize));
             }
@@ -194,18 +194,18 @@ mod tests {
         let pad_len = Range::new(comment_syntax_size, 50)
             .ind_sample(&mut rng);
         let target_size = raw_len + pad_len;
-        let ptr = pad_object(&raw, "css", target_size);
+        let obj_ptr = pad_object(&raw, "css", target_size);
         unsafe {
             for i in 0..raw_len {
-                assert_eq!(raw[i], *ptr.offset(i as isize));
+                assert_eq!(raw[i], *obj_ptr.offset(i as isize));
             }
             for i in 0..CSS_COMMENT_START_SIZE {
                 assert_eq!(CSS_COMMENT_START.as_bytes()[i],
-                           *ptr.offset(raw_len as isize + i as isize));
+                           *obj_ptr.offset(raw_len as isize + i as isize));
             }
             for i in 0..CSS_COMMENT_END_SIZE {
                 assert_eq!(CSS_COMMENT_END.as_bytes()[i],
-                           *ptr.offset(target_size as isize
+                           *obj_ptr.offset(target_size as isize
                                        - CSS_COMMENT_END_SIZE as isize
                                        + i as isize));
             }
@@ -288,10 +288,10 @@ mod tests {
         assert_eq!(raw.len(), raw_len);
         let pad_len = Range::new(0, 50).ind_sample(&mut rng);
         let target_size = raw_len + pad_len;
-        let ptr = pad_object(&raw, "alpaca", target_size);
+        let obj_ptr = pad_object(&raw, "alpaca", target_size);
         unsafe {
             for i in 0..raw_len {
-                assert_eq!(raw[i], *ptr.offset(i as isize));
+                assert_eq!(raw[i], *obj_ptr.offset(i as isize));
             }
         }
     }
@@ -331,6 +331,6 @@ mod tests {
         let raw_len = Range::new(1, 50).ind_sample(&mut rng);
         let raw = rng.gen_iter::<u8>().take(raw_len).collect::<Vec<u8>>();
         assert_eq!(raw.len(), raw_len);
-        let ptr = pad_object(&raw, "alpaca", raw_len - 1);
+        let obj_ptr = pad_object(&raw, "alpaca", raw_len - 1);
     }
 }

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -82,7 +82,6 @@ fn get_binary_padding(pad_len: usize, rng: &mut XorShiftRng) -> Vec<u8> {
 mod tests {
     use super::*;
 
-    use rand::weak_rng;
     use rand::distributions::{IndependentSample, Range};
 
     use std::str;

--- a/src/pad.rs
+++ b/src/pad.rs
@@ -53,10 +53,10 @@ fn get_html_padding(pad_len: usize, rng: &mut XorShiftRng) -> Vec<u8> {
     // and closing syntax.
     let pad_len = pad_len - HTML_COMMENT_START_SIZE - HTML_COMMENT_END_SIZE;
     let mut pad = Vec::from(HTML_COMMENT_START);
-    // [34,127) contains only human-readable ascii characters, no
-    // whitespace, and omits '!' to ensure the CSS comment cannot be ended
-    // early by the random generation of the bytes corresponding to '<!--'.
-    pad.extend(sample(rng, 34..127, pad_len));
+    // [46,127) contains only human-readable ascii characters, no
+    // whitespace, and omits '-' to ensure the HTML comment cannot be ended
+    // early by the random generation of the bytes corresponding to '-->'.
+    pad.extend(sample(rng, 46..127, pad_len));
     pad.extend(Vec::from(HTML_COMMENT_END));
     pad
 }
@@ -91,7 +91,7 @@ mod tests {
     fn test_pad_object_html() {
         let mut rng = weak_rng();
         let raw_len = Range::new(0, 50).ind_sample(&mut rng);
-        let raw = sample(&mut rng, 34..127, raw_len);
+        let raw = sample(&mut rng, 46..127, raw_len);
         assert_eq!(raw.len(), raw_len);
         let comment_syntax_size = HTML_COMMENT_START_SIZE
             + HTML_COMMENT_END_SIZE;
@@ -120,7 +120,7 @@ mod tests {
     fn test_pad_method_html() {
         let mut rng = weak_rng();
         let raw_len = Range::new(0, 50).ind_sample(&mut rng);
-        let raw = sample(&mut rng, 34..127, raw_len);
+        let raw = sample(&mut rng, 46..127, raw_len);
         let mut object = Object::from(&raw, "html");
         assert_eq!(object.content.len(), raw_len);
         assert!(match object.kind {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,10 +1,62 @@
+pub enum ObjectKind {
+    Alpaca,
+    HTML,
+    CSS,
+    IMG,
+    Unknown,
+}
 
-const ALPACA_T: usize = 0;
-const HTML_T: usize = 1;
-const CSS_T: usize = 2;
-const IMG_T: usize = 3;
-const UNKNOWN_T: usize = 4;
+pub struct Object {
+    pub kind: ObjectKind,
+    pub content: Vec<u8>,
+}
 
-pub extern fn parse_object_type(object: &[u8], request: &str) -> usize {
-    unimplemented!();
+impl Object {
+    pub fn from(raw: &[u8], content_type: &str) -> Object {
+        let kind = match content_type {
+            // Sample values for early development.
+            "alpaca" => ObjectKind::Alpaca,
+            "html"   => ObjectKind::HTML,
+            "css"    => ObjectKind::CSS,
+            "png"    => ObjectKind::IMG,
+            "jpg"    => ObjectKind::IMG,
+            _        => ObjectKind::Unknown,
+        };
+        Object {
+            kind,
+            content: raw.to_vec()
+        }
+    }
+
+    pub fn as_ptr(self) -> *const u8 {
+        self.content.as_ptr()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use rand::distributions::{IndependentSample, Range};
+    use rand::{Rng, weak_rng};
+
+
+    fn test_object_from_and_as_ptr_jpg() {
+        let mut rng = weak_rng();
+        let raw_len = Range::new(0, 50).ind_sample(&mut rng);
+        let raw = rng.gen_iter::<u8>().take(raw_len).collect::<Vec<u8>>();
+        let mut object = Object::from(&raw, "jpg");
+        assert_eq!(object.content.len(), raw_len);
+        assert!(match object.kind {
+            ObjectKind::IMG => true,
+            _               => false,
+        });
+
+        let obj_ptr = object.as_ptr();
+        unsafe {
+            for i in 0..raw_len {
+                assert_eq!(raw[i], *obj_ptr.offset(i as isize));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Got rid of `pcg_rand::Pcg32` because I didn't see the point in adding a 3rd party library. Probably should have asked you @gchers why you added it in the first place. I use `weak_rand()` because it's fast and cryptographic randomness isn't important here.