### PR TITLE
Upgrade to rand 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ name = "alpaca"
 crate-type = ["dylib"]
 
 [dependencies]
-rand = "0.3"
+rand = "0.4"


### PR DESCRIPTION
- Upgrade `rand` crate to version 0.4.

- `sample` was deprecated in 0.4 in favor of `sample_iterator`, which is good
  because while replacing it I realized I had made a mistake in using it!
  `sample`/ `sample_iterator` selects a number of items at random (not in random
  order) from a finite iterator. If the items you wish to sample is greater than
  the number in the finite iterator, it panics! What we really wanted was to
  `ind_sample()` from a `Range`, so I have implemented that below, DRYing things
  up a little in the process by adding the `add_random_chars_in_range`.

- We stop passing around `rng` references so much and instead just initialize
  `XorShiftRng`s in the two places we need them (`get_binary_padding` and
  `add_random_chars_in_range`).

- Remove type notations a couple places to clear up/ reduce code when the
  compiler can inference the types.