### PR TITLE
Pin nightly version against clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   allow_failures:
     - env: NAME='cargo-travis'
   include:
-    - rust: nightly
+    - rust: nightly-2018-02-10
       env: # use env so updating versions causes cache invalidation
         - CLIPPY_VERSION=0.0.186
       before_script:


### PR DESCRIPTION
Fixes #16. This way we don't have to recompile clippy against the latest Rust
nightly every time it updates. Every few weeks/ months we should update the
clippy and Rust version. This is less than ideal, but it was the best solution I
found (via https://dev.to/cad97/great-rust-ci-1fk6 ).